### PR TITLE
Update ` includes/analytics.html` so it can be configured via `config.yml`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,15 @@ defaults:
     -
         scope:
             path: ""
+            type: "pages"
+        values:
+            analytics: true     # google analytics ref _includes/analytics.html
+    -
+        scope:
+            path: ""
             type: "posts"
         values:
+            analytics: true     # google analytics ref _includes/analytics.html
             author: "Zack Wilson"
+            categories: uncategorized
             comments: true

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,3 +1,11 @@
+{% comment %}
+    Google Analytics Tracking Code
+    Configure default behavior in `_config.yml`
+    Default is `analytics: true` (i.e. global)
+    Toggle per layout in frontmatter with `analytics: false`
+{% endcomment %}
+{% if page.analytics %}
+<!-- Begin Google Analytics -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -8,3 +16,5 @@
   ga('send', 'pageview');
 
 </script>
+<!-- End Google Analytics -->
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,6 @@
 
     {% include footer.html %}
 
-
   </body>
 
 </html>


### PR DESCRIPTION
Previous behavior was analytics site-wide which is probably the typical
desired behavior. But just in case we want to switch analytics off on a
particular page or post, we can now do so in config.yml with the
`analytics: true|false` switch. Fails to `analytics: false`, but
default setting in config.yml for pages and posts is now `analytics:
true`.