### PR TITLE
Added if statements for includes specific to production environments

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,13 +1,30 @@
 <!DOCTYPE html>
 <html>
+  {% comment %}
+  Only include seo plugin on the live site
+  {% endcomment %}
+  {% if jekyll.environment != "development" %}
+    {% seo %}
+  {% endif %}
 
-  {% seo %}
   {% include head.html %}
-  {% include analytics.html %}
+
+  {% comment %}
+  Only track analytics on the live site
+  {% endcomment %}
+  {% if jekyll.environment != "development" %}
+    {% include analytics.html %}
+  {% endif %}
 
   <body>
 
-    {% include ads.html %}
+    {% comment %}
+    Only serve ads on the live site
+    {% endcomment %}
+    {% if jekyll.environment != "development" %}
+      {% include ads.html %}
+    {% endif %}
+
     {% include header.html %}
 
     <div class="page-content">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,11 @@ layout: default
     {{ content }}
   </div>
 
-  {% include comments.html %}
+  {% comment %}
+  Only include comment forum on the live site
+  {% endcomment %}
+  {% if jekyll.environment != "development" %}
+    {% include comments.html %}
+  {% endif %}
 
 </article>


### PR DESCRIPTION
Ads won’t be served, analytics won’t be tracked, and comments will be
disabled when serving the site locally, unless specified with the build
variable (`JEKYLL_ENV=“production”`)